### PR TITLE
When copying a version, get the source BOM from the network.

### DIFF
--- a/core/src/main/kotlin/io/spinnaker/spinrel/BomStorage.kt
+++ b/core/src/main/kotlin/io/spinnaker/spinrel/BomStorage.kt
@@ -1,0 +1,17 @@
+package io.spinnaker.spinrel
+
+import java.nio.ByteBuffer
+import javax.inject.Inject
+
+class BomStorage @Inject constructor(private val storage: GoogleCloudStorage) {
+
+    fun get(version: String) = Bom.readFromString(storage.readUtf8String("bom/$version.yml"))
+
+    fun put(bom: Bom) {
+        val gcsPath = "bom/${bom.version}.yml"
+        val writer = storage.writer(gcsPath) { blobInfo -> blobInfo.setContentType("application/x-yaml") }
+        writer.use {
+            it.write(ByteBuffer.wrap(bom.toYaml().toByteArray(Charsets.UTF_8)))
+        }
+    }
+}

--- a/core/src/main/kotlin/io/spinnaker/spinrel/VersionPublisher.kt
+++ b/core/src/main/kotlin/io/spinnaker/spinrel/VersionPublisher.kt
@@ -1,11 +1,10 @@
 package io.spinnaker.spinrel
 
-import java.nio.ByteBuffer
 import javax.inject.Inject
 import mu.KotlinLogging
 
 class VersionPublisher @Inject constructor(
-    private val cloudStorage: GoogleCloudStorage,
+    private val bomStorage: BomStorage,
     private val containerRegistry: ContainerRegistry,
     private val serviceRegistry: SpinnakerServiceRegistry,
     private val tagGenerator: ContainerTagGenerator
@@ -23,13 +22,8 @@ class VersionPublisher @Inject constructor(
     }
 
     private fun uploadBomToGcs(bom: Bom, version: String) {
-        val gcsPath = "bom/$version.yml"
-        logger.info { "Writing $gcsPath to GCS bucket ${cloudStorage.bucket}" }
         val versionedBom = bom.copy(version = version)
-        val writer = cloudStorage.writer(gcsPath) { blobInfo -> blobInfo.setContentType("application/x-yaml") }
-        writer.use {
-            it.write(ByteBuffer.wrap(versionedBom.toYaml().toByteArray(Charsets.UTF_8)))
-        }
+        bomStorage.put(versionedBom)
     }
 
     private fun tagContainers(bom: Bom, spinnakerVersion: String) {

--- a/core/src/test/kotlin/io/spinnaker/spinrel/VersionPublisherTest.kt
+++ b/core/src/test/kotlin/io/spinnaker/spinrel/VersionPublisherTest.kt
@@ -16,7 +16,7 @@ class VersionPublisherTest {
 
     private lateinit var versionPublisher: VersionPublisher
 
-    private lateinit var cloudStorage: GoogleCloudStorage
+    private lateinit var bomStorage: BomStorage
 
     @MockK(relaxUnitFun = true)
     private lateinit var containerRegistry: ContainerRegistry
@@ -31,9 +31,9 @@ class VersionPublisherTest {
         serviceRegistry = mutableSetOf()
 
         val storage = LocalStorageHelper.getOptions().service
-        cloudStorage = GoogleCloudStorage(storage, GcsBucket("gcsBucket"))
+        bomStorage = BomStorage(GoogleCloudStorage(storage, GcsBucket("gcsBucket")))
         versionPublisher = VersionPublisher(
-            cloudStorage,
+            bomStorage,
             containerRegistry,
             object : SpinnakerServiceRegistry {
                 override val byServiceName: Map<String, SpinnakerServiceInfo>
@@ -51,7 +51,7 @@ class VersionPublisherTest {
         val bom = createMinimalBomWithVersion("1.2.3")
         versionPublisher.publish(bom, "4.5.6")
 
-        val storedBom = Bom.readFromString(cloudStorage.readUtf8String("bom/4.5.6.yml"))
+        val storedBom = bomStorage.get("4.5.6")
 
         expectThat(storedBom).isEqualTo(bom.copy(version = "4.5.6"))
     }

--- a/jenkins-cli/src/main/kotlin/io/spinnaker/spinrel/cli/jenkins/Main.kt
+++ b/jenkins-cli/src/main/kotlin/io/spinnaker/spinrel/cli/jenkins/Main.kt
@@ -9,7 +9,6 @@ import dagger.Component
 import io.spinnaker.spinrel.GcrProject
 import io.spinnaker.spinrel.GcsBucket
 import io.spinnaker.spinrel.GoogleApiHttpClientModule
-import io.spinnaker.spinrel.GoogleAuthModule
 import io.spinnaker.spinrel.GoogleCloudStorageModule
 import io.spinnaker.spinrel.GoogleContainerRegistryModule
 import io.spinnaker.spinrel.cli.ProductionConfigModule


### PR DESCRIPTION
This will be used to copy `master-latest-unvalidated` to `master-latest-validated`.

I thought the current code was getting the source BOM from disk, but it turns out it actually pulls it from GCS, so this makes `spinrel` do the same. (I'm sure it still exists on disk somewhere, since we just created it earlier, but this feels safer anyway, plus it matches the current behavior.)