### PR TITLE
 chore(containers): stop tagging the Java 8 containers

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,12 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
     - name: Build
       env:
         GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false

--- a/core/src/main/kotlin/io/spinnaker/spinrel/ContainerTagGenerator.kt
+++ b/core/src/main/kotlin/io/spinnaker/spinrel/ContainerTagGenerator.kt
@@ -14,7 +14,7 @@ interface ContainerTagGenerator {
 class DefaultContainerTagGenerator @Inject constructor() :
     ContainerTagGenerator {
 
-    private val tagSuffixes = setOf("", "-slim", "-ubuntu", "-java8", "-ubuntu-java8")
+    private val tagSuffixes = setOf("", "-slim", "-ubuntu")
 
     override fun generateTagsForVersion(version: String): Set<String> = tagSuffixes.map { "$version$it" }.toSet()
 }


### PR DESCRIPTION
 They're not longer built as of spinnaker/buildtool#85